### PR TITLE
Fix Chrome(>=109) removed event.path

### DIFF
--- a/src/content/devices/multi/js/main.js
+++ b/src/content/devices/multi/js/main.js
@@ -72,7 +72,7 @@ function changeAudioDestination(event) {
   const deviceId = event.target.value;
   const outputSelector = event.target;
   // FIXME: Make the media element lookup dynamic.
-  const element = event.path[2].childNodes[1];
+  const element = event.composedPath()[2].childNodes[1];
   attachSinkId(element, deviceId, outputSelector);
 }
 


### PR DESCRIPTION
**Description**
When i switch audio output, the error occured. 
Because of Chrome(>=109) removed `event.path`, so change the method of get audio element 


more see: 
https://bugs.chromium.org/p/chromium/issues/detail?id=1277431